### PR TITLE
Xcode 15 beta compatibility

### DIFF
--- a/AlternateIcons.xcodeproj/project.pbxproj
+++ b/AlternateIcons.xcodeproj/project.pbxproj
@@ -351,8 +351,17 @@
 			attributes = {
 				LastUpgradeCheck = 1020;
 				TargetAttributes = {
+					"AlternateIcons::AltKit" = {
+						LastSwiftMigration = "";
+					};
+					"AlternateIcons::AltKitTests" = {
+						LastSwiftMigration = "";
+					};
+					"AlternateIcons::AlternateIcons" = {
+						LastSwiftMigration = "";
+					};
 					"Files::Files" = {
-						LastSwiftMigration = 1020;
+						LastSwiftMigration = "";
 					};
 				};
 			};
@@ -521,7 +530,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "-DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -588,7 +597,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				OTHER_SWIFT_FLAGS = "-DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -634,7 +643,7 @@
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
 				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = AlternateIcons;
 			};
 			name = Debug;
@@ -654,7 +663,7 @@
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
 				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = AlternateIcons;
 			};
 			name = Release;
@@ -673,7 +682,7 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = AltKitTests;
 			};
 			name = Debug;
@@ -692,7 +701,7 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = AltKitTests;
 			};
 			name = Release;
@@ -715,7 +724,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = AltKit;
 			};
 			name = Debug;
@@ -738,7 +747,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = AltKit;
 			};
 			name = Release;
@@ -764,7 +773,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = Files;
 			};
 			name = Debug;
@@ -789,7 +798,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGET_NAME = Files;
 			};
 			name = Release;

--- a/AlternateIcons.xcodeproj/project.pbxproj
+++ b/AlternateIcons.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -349,7 +349,8 @@
 		OBJ_1 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					"AlternateIcons::AltKit" = {
 						LastSwiftMigration = "";
@@ -510,6 +511,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -517,6 +519,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_NS_ASSERTIONS = YES;
@@ -545,6 +548,7 @@
 		OBJ_36 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
 				LD = /usr/bin/true;
 				OTHER_SWIFT_FLAGS = "-swift-version 4 -I /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -555,6 +559,7 @@
 		OBJ_37 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
 				LD = /usr/bin/true;
 				OTHER_SWIFT_FLAGS = "-swift-version 4 -I /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -579,6 +584,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -586,6 +592,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -603,7 +610,8 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				USE_HEADERMAP = NO;
 			};
 			name = Release;
@@ -611,6 +619,7 @@
 		OBJ_42 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
 				LD = /usr/bin/true;
 				OTHER_SWIFT_FLAGS = "-swift-version 4 -I /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -621,6 +630,7 @@
 		OBJ_43 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
 				LD = /usr/bin/true;
 				OTHER_SWIFT_FLAGS = "-swift-version 4 -I /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -631,13 +641,17 @@
 		OBJ_48 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AlternateIcons.xcodeproj/AlternateIcons_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+					"@executable_path",
+				);
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
@@ -651,13 +665,17 @@
 		OBJ_49 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AlternateIcons.xcodeproj/AlternateIcons_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+					"@executable_path",
+				);
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
@@ -672,13 +690,17 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AlternateIcons.xcodeproj/AltKitTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@loader_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -691,13 +713,17 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AlternateIcons.xcodeproj/AltKitTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@loader_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -709,6 +735,7 @@
 		OBJ_74 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -732,6 +759,7 @@
 		OBJ_75 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -756,7 +784,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
+				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -765,6 +795,8 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AlternateIcons.xcodeproj/Files_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = Files;
@@ -782,7 +814,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
+				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -791,6 +825,8 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AlternateIcons.xcodeproj/Files_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = Files;
@@ -806,12 +842,14 @@
 		OBJ_95 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
 			};
 			name = Debug;
 		};
 		OBJ_96 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
 			};
 			name = Release;
 		};

--- a/AlternateIcons.xcodeproj/xcshareddata/xcschemes/AltKit.xcscheme
+++ b/AlternateIcons.xcodeproj/xcshareddata/xcschemes/AltKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,20 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "NO">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AlternateIcons::AltKitTests"
-               BuildableName = "AltKitTests.xctest"
-               BlueprintName = "AltKitTests"
-               ReferencedContainer = "container:AlternateIcons.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      codeCoverageEnabled = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -66,8 +54,18 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AlternateIcons::AltKitTests"
+               BuildableName = "AltKitTests.xctest"
+               BlueprintName = "AltKitTests"
+               ReferencedContainer = "container:AlternateIcons.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -88,8 +86,6 @@
             ReferencedContainer = "container:AlternateIcons.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/AlternateIcons.xcodeproj/xcshareddata/xcschemes/AlternateIcons.xcscheme
+++ b/AlternateIcons.xcodeproj/xcshareddata/xcschemes/AlternateIcons.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,20 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "NO">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AlternateIcons::AltKitTests"
-               BuildableName = "AltKitTests.xctest"
-               BlueprintName = "AltKitTests"
-               ReferencedContainer = "container:AlternateIcons.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      codeCoverageEnabled = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -66,8 +54,18 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AlternateIcons::AltKitTests"
+               BuildableName = "AltKitTests.xctest"
+               BlueprintName = "AltKitTests"
+               ReferencedContainer = "container:AlternateIcons.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -89,8 +87,6 @@
             ReferencedContainer = "container:AlternateIcons.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ INSTALL_PATH = /usr/local/bin/embed-alternate-icons
 build:
 	swift package clean
 	swift package update
-	swift build -c release
+	swift build -c release --arch arm64 --arch x86_64
 
 install:
 	cp -f .build/release/AlternateIcons $(INSTALL_PATH)

--- a/Package.swift
+++ b/Package.swift
@@ -1,15 +1,18 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.8
 
 import PackageDescription
 
 let package = Package(
     name: "AlternateIcons",
+    platforms: [
+        .macOS(.v13),
+    ],
     dependencies: [
         .package(url: "https://github.com/JohnSundell/Files.git", from: "2.0.0")
     ],
     targets: [
         .target(name: "AltKit", dependencies: ["Files"]),
-        .target(name: "AlternateIcons", dependencies: ["AltKit"]),
+        .executableTarget(name: "AlternateIcons", dependencies: ["AltKit"]),
         .testTarget(name: "AltKitTests", dependencies: ["AltKit"])
     ]
 )

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ To set up AlternateIcons as an Xcode build phase, do the following:
     
     ~~~
     $(SRCROOT)/AlternateIcons.xcassets
+    $(SRCROOT)/MyApp/Info.plist
+    ~~~
+
+    Specify the Info.plist file to be written in Output Files:
+
+    ~~~
+    $(DERIVED_FILE_DIR)/MyApp-Generated-Info.plist
+    ~~~
+
+    Update "Info.plist File" (`GENERATE_INFOPLIST_FILE`) in the app target settings (this assumes `GENERATE_INFOPLIST_FILE` is `NO`):
+
+    ~~~
+    $(DERIVED_FILE_DIR)/MyApp-Generated-Info.plist
     ~~~
 
     **NOTE**: This Run Script phase needs to be the last build phase in your build.

--- a/Sources/AltKit/AppIconSet.swift
+++ b/Sources/AltKit/AppIconSet.swift
@@ -14,7 +14,7 @@ class AppIconSet {
     /// An image from the set.
     ///
 
-    struct Image: Decodable {
+    struct Image: Decodable, Hashable {
 
         /// The name of the `.png` file.
         let filename: String?
@@ -27,7 +27,14 @@ class AppIconSet {
 
         /// The scale of the icon.
         let scale: String
-        
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(filename)
+            hasher.combine(idiom)
+            hasher.combine(size)
+            hasher.combine(scale)
+        }
+
     }
 
 
@@ -126,8 +133,10 @@ extension AppIconSet.Image: Equatable {
 
 extension AppIconSet: Hashable {
 
-    var hashValue: Int {
-        return ObjectIdentifier(self).hashValue
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(folder.path)
+        hasher.combine(images)
+        hasher.combine(name)
     }
 
     static func == (lhs: AppIconSet, rhs: AppIconSet) -> Bool {

--- a/Sources/AltKit/BundleIcon.swift
+++ b/Sources/AltKit/BundleIcon.swift
@@ -9,8 +9,9 @@ struct BundleIcon: Hashable {
     let name: String
     let files: [String]
 
-    var hashValue: Int {
-        return name.hashValue
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(files)
     }
 
     static func == (lhs: BundleIcon, rhs: BundleIcon) -> Bool {

--- a/Sources/AltKit/Error.swift
+++ b/Sources/AltKit/Error.swift
@@ -21,6 +21,9 @@ enum AltError: String, LocalizedError {
     /// No app icon set named 'AppIcon' was found.
     case noPrimaryIconSet = "No app icon set named 'AppIcon' was found."
 
+    /// The Info.plist file could not be read.
+    case noOutputPlistPath = "No output path for the updated Info.plist was specified."
+
     var errorDescription: String? {
         return rawValue
     }

--- a/Sources/AltKit/InfoPlist.swift
+++ b/Sources/AltKit/InfoPlist.swift
@@ -89,9 +89,10 @@ class InfoPlist {
     /// testing purposes.
     ///
 
-    func commitChanges() throws {
+    func commitChanges(to destinationURL: URL) throws {
         let plistData = try PropertyListSerialization.data(fromPropertyList: infoDictionary, format: .xml, options: 0)
-        try file.write(data: plistData)
+
+        try plistData.write(to: destinationURL, options: .atomic)
     }
 
 }

--- a/Sources/AltKit/Script.swift
+++ b/Sources/AltKit/Script.swift
@@ -176,7 +176,7 @@ extension String {
             return self
         }
 
-        let startIndex = index(endIndex, offsetBy: -`extension`.characters.count - 1)
+        let startIndex = index(endIndex, offsetBy: -`extension`.count - 1)
         return replacingCharacters(in: startIndex..<endIndex, with: "")
     }
 

--- a/Sources/AltKit/Script.swift
+++ b/Sources/AltKit/Script.swift
@@ -22,6 +22,9 @@ public enum Script {
         /// The app bundle.
         let appBundle: Folder
 
+        /// Output path of the updated plist file.
+        let outputInfoPlistURL: URL
+
     }
 
 
@@ -35,8 +38,7 @@ public enum Script {
 
     public static func readArguments(resolvingAgainst basePath: String = "") throws -> Arguments {
 
-        // 1) Asset Catalog
-
+        // Check parameters
         guard let scriptInputFiles = Xcode.scriptInputFiles else {
             throw AltError.noAssetCatalog
         }
@@ -44,6 +46,20 @@ public enum Script {
         guard scriptInputFiles.count > 0 else {
             throw AltError.noAssetCatalog
         }
+
+        guard scriptInputFiles.count > 1 else {
+            throw AltError.noInfoPlist
+        }
+
+        guard let scriptOutputFiles = Xcode.scriptOutputFiles else {
+            throw AltError.noOutputPlistPath
+        }
+
+        guard scriptOutputFiles.count > 0 else {
+            throw AltError.noOutputPlistPath
+        }
+
+        // 1) Asset Catalog
 
         let assetCatalogPath = scriptInputFiles[0]
         let assetCatalogFolder = try Folder(path: basePath + assetCatalogPath)
@@ -60,16 +76,21 @@ public enum Script {
 
         // 3) Info Plist
 
-        let infoPlistPath = appBundlePath.appending(pathComponent: "Info.plist")
+        let infoPlistPath = scriptInputFiles[1]
         let infoPlistFile = try File(path: infoPlistPath)
 
         let infoPlist = try InfoPlist(file: infoPlistFile)
         let assetCatalog = AssetCatalog(folder: assetCatalogFolder)
         let appBundle = try Folder(path: appBundlePath)
 
+        // 3) Output Path
+
+        let outputInfoPlistURL = URL(filePath: scriptOutputFiles[0], directoryHint: .notDirectory)
+
         return Arguments(infoPlist: infoPlist,
                          assetCatalog: assetCatalog,
-                         appBundle: appBundle)
+                         appBundle: appBundle,
+                         outputInfoPlistURL: outputInfoPlistURL)
 
     }
 
@@ -108,7 +129,7 @@ public enum Script {
         step("Updating Info.plist with new icons")
 
         arguments.infoPlist.update(alternateIcons: alternateIconSets)
-        try arguments.infoPlist.commitChanges()
+        try arguments.infoPlist.commitChanges(to: arguments.outputInfoPlistURL)
 
     }
 

--- a/Sources/AltKit/Xcode.swift
+++ b/Sources/AltKit/Xcode.swift
@@ -39,6 +39,29 @@ enum Xcode {
 
     }
 
+    /// The output files of the script.
+    static var scriptOutputFiles: [String]? {
+
+        guard let count = get(variable: "SCRIPT_OUTPUT_FILE_COUNT").flatMap({ Int($0) }) else {
+            return nil
+        }
+
+        var outputFiles = [String]()
+
+        for index in 0 ..< count {
+
+            guard let path = get(variable: "SCRIPT_OUTPUT_FILE_\(index)") else {
+                return nil
+            }
+
+            outputFiles.append(path)
+
+        }
+
+        return outputFiles
+
+    }
+
 
     // MARK: - Utilities
 

--- a/Tests/AltKitTests/InfoPlistTests.swift
+++ b/Tests/AltKitTests/InfoPlistTests.swift
@@ -146,7 +146,7 @@ extension InfoPlist {
             return nil
         }
 
-        return alternateIconsDictionary.flatMap {
+        return alternateIconsDictionary.compactMap {
 
             guard let files = $0.value[InfoPlist.iconFilesKey] as? [String] else {
                 return nil


### PR DESCRIPTION
Trying to update the generated Info.plist directly in the built product no longer works reliably with Xcode 15. Instead we now read the input Info.plist, write an updated Info.plist to a temporary location, then use the generated Info.plist as the Info.plist file in the target settings.

Note that this approach won't work if `GENERATE_INFOPLIST_FILE` is `YES` (which we don't use in our projects).

Also updates to Swift 5, builds a universal binary, and other cleanup.